### PR TITLE
Let the padding generator use configured seed

### DIFF
--- a/woodblock/datagen.py
+++ b/woodblock/datagen.py
@@ -17,10 +17,12 @@ class Zeroes:
 class Random:
     """Generates random bytes."""
 
-    def __init__(self, rng=RandomBytes()):
-        self._seed = random.randint(0, 2 ** 32 - 1)  # nosec
+    def __init__(self, rng=RandomBytes(), seed=None):
+        if not seed:
+            seed = random.randint(0, 2 ** 32 - 1)  # nosec
+        self._seed = seed
         self._rng = rng
-        self._rng.seed(self._seed)
+        self._rng.seed(seed)
 
     def __call__(self, size):
         return self._rng.bytes(size)

--- a/woodblock/image.py
+++ b/woodblock/image.py
@@ -25,10 +25,12 @@ class Image:
         padding_generator: A data generator used to generate padding.
     """
 
-    def __init__(self, block_size: int = 512, padding_generator=woodblock.datagen.Random()):
+    def __init__(self, block_size: int = 512, padding_generator=None, seed=None):
         self._block_size = block_size
         self._scenarios = list()
         self._generate_padding = padding_generator
+        if not self._generate_padding:
+            self._generate_padding = woodblock.datagen.Random(seed=seed)
 
     def add(self, scenario):
         """Add a ``Scenario`` to the image."""
@@ -52,7 +54,7 @@ class Image:
         if 'seed' in general:
             woodblock.random.seed(general['seed'])
         num_filler_blocks = (general['min filler blocks'], general['max filler blocks'])
-        image = Image()
+        image = Image(seed=general['seed'] if 'seed' in general else None)
         for section in config.sections():
             if section != 'general':
                 scenario = _parse_scenario_section(section_name=section, section=config[section],


### PR DESCRIPTION
When producing images, the padding gets filled up with random bytes.
However, this padding is non-deterministic for each invocation:

```
$ woodblock generate my.conf out.dd ; sha1sum out.dd 
76ea06addd4d25ba3cded26e2bd816db0a3b29c3  out.dd

$ woodblock generate my.conf out.dd ; sha1sum out.dd 
e52d38a4df78e5e42189d260cac0f2f57fc6e978  out.dd
```

I would argue, that generating reproducible images is beneficial
for researchers, as it helps to reproduce your results as a whole.
Therefore the random-padding should take its seed from the configuration.

After the patch it looks like this:
```
$ woodblock generate my.conf out.dd ; sha1sum out.dd 
a0140fd62eb9e6a35a1b95df2bd655731bca221f  out.dd
$ woodblock generate my.conf out.dd ; sha1sum out.dd 
a0140fd62eb9e6a35a1b95df2bd655731bca221f  out.dd
```

I don't think this patch fits your coding style, so feel free to just
see it as an inspiration. If you rewrite it however, keep in mind, that
the produced deterministic padding should be non-repeated of course.
That means that the padding of one block should not be the same as that of
another.